### PR TITLE
chore: remove dependency on @backstage/core-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@backstage/catalog-model": "^0.2.0",
     "@backstage/core": "^0.3.0",
-    "@backstage/core-api": "^0.2.1",
     "@backstage/plugin-catalog": "^0.2.1",
     "@backstage/theme": "^0.2.1",
     "@material-ui/core": "^4.9.1",


### PR DESCRIPTION
This package is not supposed to be directly depended on; its vital parts are exported by `@backstage/core` which is the intended public import.