### PR TITLE
add authorization to travis-ci api requests

### DIFF
--- a/src/components/LastBuildCard.test.tsx
+++ b/src/components/LastBuildCard.test.tsx
@@ -19,6 +19,7 @@ import { render } from '@testing-library/react';
 import {
   ApiRegistry,
   ApiProvider,
+  IdentityApi,
   UrlPatternDiscovery,
   errorApiRef,
   configApiRef,
@@ -35,6 +36,20 @@ import { MemoryRouter } from 'react-router-dom';
 
 const discoveryApi = UrlPatternDiscovery.compile('http://exampleapi.com');
 const errorApiMock = { post: jest.fn(), error$: jest.fn() };
+const identityApi: IdentityApi = {
+  getUserId() {
+    return 'jane-fonda';
+  },
+  getProfile() {
+    return { email: 'jane-fonda@spotify.com' };
+  },
+  async getIdToken() {
+    return Promise.resolve('fake-id-token');
+  },
+  async signOut() {
+    return Promise.resolve();
+  },
+};
 
 const config = {
   getString: (_: string) => undefined,
@@ -43,7 +58,7 @@ const config = {
 const apis = ApiRegistry.from([
   [configApiRef, config],
   [errorApiRef, errorApiMock],
-  [travisCIApiRef, new TravisCIApiClient({ discoveryApi })],
+  [travisCIApiRef, new TravisCIApiClient({ discoveryApi, identityApi })],
 ]);
 describe('LastBuildCard', () => {
   const worker = setupServer();

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,6 +2,7 @@ import {
   createApiFactory,
   createPlugin,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core';
 import { TravisCIApiClient, travisCIApiRef } from './api';
 
@@ -10,8 +11,8 @@ export const plugin = createPlugin({
   apis: [
     createApiFactory({
       api: travisCIApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new TravisCIApiClient({ discoveryApi }),
+      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+      factory: ({ discoveryApi, identityApi }) => new TravisCIApiClient({ discoveryApi, identityApi }),
     }),
   ],
 });


### PR DESCRIPTION
With #3916 adopters can require authorization for backend api requests. For this to work all clients need to send an authorization header. This PR adds that authorization header to travis-ci requests, as per the standard established in #3914.